### PR TITLE
fix bench

### DIFF
--- a/ComparisonBenchmarks.cs
+++ b/ComparisonBenchmarks.cs
@@ -1,32 +1,28 @@
 ﻿using System.Text;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using forsen;
 
 namespace libs_comparison;
-[MemoryDiagnoser(true)]
+
+[MemoryDiagnoser]
+[SimpleJob, SimpleJob(RuntimeMoniker.NativeAot80)]
 public class ComparisonBenchmarks
 {
-    private readonly List<ReadOnlyMemory<byte>> dataLines = new();
-    private readonly List<string> stringLines = new();
+    private byte[][] dataLines = null!;
+    private string[] stringLines = null!;
 
     [GlobalSetup]
     public void AddData()
     {
-        string[] lines = File.ReadLines("data.txt").Take(1000).ToArray();
-
-        foreach (string line in lines)
-        {
-            stringLines.Add(line);
-            dataLines.Add(Encoding.UTF8.GetBytes(line));
-        }
-
-        Console.WriteLine($"Added {dataLines.Count} lines");
+        stringLines = File.ReadLines("data.txt").Take(1000).ToArray();
+        dataLines = stringLines.Select(Encoding.UTF8.GetBytes).ToArray();
     }
 
     [Benchmark]
     public void MiniTwitchParse()
     {
-        foreach (ReadOnlyMemory<byte> item in dataLines)
+        foreach (var item in dataLines)
         {
             MiniTwitch.Process(item);
         }
@@ -40,12 +36,4 @@ public class ComparisonBenchmarks
             TwitchLib.HandleIrcMessage(TwitchLib.ParseIrcMessage(item));
         }
     } */
-
-    [GlobalCleanup]
-    public void Cleanup()
-    {
-        Console.WriteLine($"Clearing {dataLines.Count} lines");
-        dataLines.Clear();
-        stringLines.Clear();
-    }
 }

--- a/MiniTwitch.cs
+++ b/MiniTwitch.cs
@@ -1,6 +1,7 @@
 ﻿using System.Buffers;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace libs_comparison;
@@ -1638,7 +1639,7 @@ public enum RoomstateType
 }
 
 public readonly record struct IrcTag(ReadOnlyMemory<byte> Key, ReadOnlyMemory<byte> Value);
-public readonly struct IrcTags : IDisposable, IEnumerable
+public readonly struct IrcTags : IDisposable
 {
     public int Count { get; }
     private IrcTag[] Tags { get; }
@@ -1651,17 +1652,11 @@ public readonly struct IrcTags : IDisposable, IEnumerable
 
     public void Dispose() => ArrayPool<IrcTag>.Shared.Return(this.Tags, true);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Span<IrcTag>.Enumerator GetEnumerator() => this.Tags.AsSpan().GetEnumerator();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Add(int index, ReadOnlyMemory<byte> Key, ReadOnlyMemory<byte> Value) => this.Tags[index] = new(Key, Value);
-
-    public IEnumerator<IrcTag> GetEnumerator()
-    {
-        for (int x = 0; x < this.Count; x++)
-        {
-            yield return this.Tags[x];
-        }
-    }
-
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }
 
 public class IrcClient

--- a/Program.cs
+++ b/Program.cs
@@ -3,13 +3,6 @@ using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 using libs_comparison;
+using Microsoft.Extensions.DependencyInjection;
 
-
-ManualConfig config = DefaultConfig.Instance
-    .AddJob(Job
-         .MediumRun
-         .WithLaunchCount(1)
-         .WithWarmupCount(5)
-         .WithIterationCount(5)
-         .WithToolchain(InProcessNoEmitToolchain.Instance));
-BenchmarkRunner.Run<ComparisonBenchmarks>(config);
+BenchmarkRunner.Run<ComparisonBenchmarks>();

--- a/libs-comparison.csproj
+++ b/libs-comparison.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="data.txt" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- let BDN pick execution strategy automatically
- test both AOT and JIT
- backport (now merged) [Foretack/MiniTwitch#12](https://github.com/Foretack/MiniTwitch/pull/12)
- don't use List<T> in benchmark (it is not `Vec<T>`, it is `Vec<T>` found in a garbage bin behind Walmart similar to many stdlib containers in C++, will get better in the future though)
- Include data.txt in the build so you don't need to hack it with config to solve path issue

Also, you don't need to copy library code, you can just `dotnet add package MiniTwitch.Irc`.